### PR TITLE
release 2.0.0 major upgrade, backwards incompatible.  Please see READ…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: ruby
 rvm:
-  - "2.1.7"
-  - "2.2.3"
+  - '2.1.7'
+  - '2.2.5'
+  - '2.3.1'
 script: bundle exec rspec spec
 bundler_args: --without development debugger

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+# 2.0.0
+  - Major backwards compatible change.  A common if perhaps upspoken thought
+  of many good developers I have known is "I hate what I wrote yesterday"
+  Well, for whatever reason (that I cannot recall or even fathom) this gem was
+  originally written using a private key for encrypting a value, and a public
+  key to decrypt.  While that is not itself insecure, it's a terrible
+  practice and makes it easy for humans to make errors.
+  So starting in version 2.0.0 encrpyt methods will use public key and
+  decrypt will use private key, as is conventional
+  - raise on trying to decrypt with a public key
+  - code cleanup (style, remove spork remnant)
+  - bump travis ruby versions to secure versions
+
 # 1.0.5
   - updated gem groups, updated travis to run without debugger and development groups
 # 1.0.4

--- a/Guardfile
+++ b/Guardfile
@@ -1,16 +1,10 @@
 # A sample Guardfile
 # More info at https://github.com/guard/guard#readme
 
-guard 'rspec', all_after_pass: true, failed_mode: :focus, all_on_start: true, cmd: 'rspec spec --drb --debugger' do
+guard 'rspec', all_after_pass: true, failed_mode: :focus, all_on_start: true, cmd: 'rspec' do
   watch(%r{^spec/.+_spec\.rb$})
   watch(%r{^lib/(.+)\.rb$}){ |m| "spec/lib/#{m[1]}_spec.rb" }
   watch('spec/spec_helper.rb'){ "spec" }
   watch(%r{^spec/support/(.+)\.rb$})                  { "spec" }
-end
-
-guard 'spork', :test_unit => false do
-  watch('Gemfile')
-  watch('Gemfile.lock')
-  watch('spec/spec_helper.rb') { :rspec }
 end
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,15 @@
 
 Simple encryption relying on convention and designed to be used inline as string replacements.
 
+PLEASE upgrade to version 2.0 - previous versions lend themselves to making
+human errors which could lead to exploitation.
+
+## Upgrading from 1.0 to 2.0
+
+1. Recommended, but optional - generate a new RSA key pair
+2. For a properly configured production environment, simply configure with a private key
+3. Pass along the public key to any developers on the team that will need to encrypt new values
+
 ## Usage
 
 Imagine you have a file named `database.yml` that contains passwords.
@@ -17,3 +26,19 @@ After:
 ```ruby
 password: <%= InlineEncryption.decrypt(encrypted stuff goes here) %>
 ```
+
+To set up:
+
+```ruby
+InlineEncryption.config[:key] = '/some/rsa_key'
+```
+
+An example of different keys per environment:
+
+```ruby
+InlineEncryption.config[:key] = ENV['INLINE_ENCRYPTION_KEY']
+```
+
+
+If you've configured with a private key, you can both encrypt and decrypt.  If you've
+configured with a public key, you can only encrypt.

--- a/config/locales.yml
+++ b/config/locales.yml
@@ -3,8 +3,10 @@ en:
   encrypted: 'Encrypted: %{data}'
   error:
     missing_key: "missing variable: 'key'"
+    pub_key_decrypt: "Tried to decrypt with a public key.  If you really need this ability, please use version ~> 1.0"
 es:
   target: 'Destino: %{data}'
   encrypted: 'Encriptado: %{data}'
   error:
     missing_key: "variable que falta: 'key'"
+    pub_key_decrypt: "Intentado decriptar con llave publica.  Si de veras necesitas esta capabilidad, favor de user version ~> 1.0"

--- a/inline_encryption.gemspec
+++ b/inline_encryption.gemspec
@@ -1,5 +1,4 @@
 # -*- encoding: utf-8 -*-
-require 'base64'
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'inline_encryption/version'
@@ -8,7 +7,7 @@ Gem::Specification.new do |spec|
   spec.name          = 'inline_encryption'
   spec.version       = InlineEncryption::VERSION
   spec.authors       = ['rubyisbeautiful']
-  spec.email         = ['YmNwdGF5bG9yQGdtYWlsLmNvbQ==\n'].collect{ |foo| Base64.decode64(foo) }
+  spec.email         = 'bcptaylor@gmail.com'
   spec.description   = %q{ A simple encryption tool based on common convention }
   spec.summary       = %q{ A simple encryption tool based on common convention and designed as a drop in for Stringish things }
   spec.homepage      = 'http://github.com/rubyisbeautiful/inline_encryption'
@@ -18,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 1.9.3'
+  spec.required_ruby_version = '>= 2.1.5'
 
   spec.executables   = ['inline_encryption']
 

--- a/lib/inline_encryption/base.rb
+++ b/lib/inline_encryption/base.rb
@@ -12,7 +12,7 @@ module InlineEncryption
       config.check_required_variables
 
       begin
-        encrypted = config.real_key.private_encrypt(data)
+        encrypted = config.real_key.public_encrypt(data)
         converted = Base64.encode64(encrypted)
       rescue => e
         err = EncryptionFailureError.exception I18n.t('target', data: data)
@@ -39,11 +39,11 @@ module InlineEncryption
     # @raise [DecryptionFailureError] couldn't decrypt the target
     def decrypt!(data)
       config.check_required_variables
+      raise MisconfigurationError.new(I18n.t('error.pub_key_decrypt')) unless config.real_key.private?
 
       begin
         converted = Base64.decode64(data)
-        this_key = config.real_key.private? ? config.real_key.public_key : config.real_key
-        decrypted = this_key.public_decrypt(converted)
+        decrypted = config.real_key.private_decrypt(converted)
       rescue => e
         err = DecryptionFailureError.exception I18n.t('encrypted', data)
         raise err

--- a/lib/inline_encryption/errors.rb
+++ b/lib/inline_encryption/errors.rb
@@ -3,5 +3,6 @@ module InlineEncryption
   class MissingRequiredVariableError < StandardError; end
   class DecryptionFailureError < StandardError; end
   class EncryptionFailureError < StandardError; end
+  class MisconfigurationError < StandardError; end
 
 end

--- a/lib/inline_encryption/version.rb
+++ b/lib/inline_encryption/version.rb
@@ -1,3 +1,3 @@
 module InlineEncryption
-  VERSION = '1.0.5'
+  VERSION = '2.0.0'
 end

--- a/spec/inline_encryption/base_spec.rb
+++ b/spec/inline_encryption/base_spec.rb
@@ -7,16 +7,16 @@ describe InlineEncryption::Base do
     @default_key = OpenSSL::PKey::RSA.generate(2048)
   end
 
-  before :each do
-    InlineEncryption.config[:key] = @default_key
-  end
-
   describe 'encrypt' do
 
     let(:str){ 'foo' }
 
+    before :each do
+      InlineEncryption.config[:key] = @default_key
+    end
+
     it 'should encrypt' do
-      expect(InlineEncryption.encrypt(str)).to eq(Base64.encode64(@default_key.private_encrypt(str)))
+      expect(InlineEncryption.encrypt(str)).not_to eq(str)
     end
 
     it 'should fail to encrpyt and return the target' do
@@ -34,8 +34,12 @@ describe InlineEncryption::Base do
   describe 'encrypt!' do
     let(:str){ 'foo' }
 
+    before :each do
+      InlineEncryption.config[:key] = @default_key
+    end
+
     it 'should encrypt' do
-      expect(InlineEncryption.encrypt!(str)).to eq(Base64.encode64(@default_key.private_encrypt(str)))
+      expect(InlineEncryption.encrypt!(str)).not_to eq(str)
     end
 
     it 'should fail to encrpyt and raise' do
@@ -48,10 +52,11 @@ describe InlineEncryption::Base do
   describe 'decrypt' do
 
     before :all do
-      @str = Base64.encode64(@default_key.private_encrypt('chunky'))
+      @str = Base64.encode64(@default_key.public_encrypt('chunky'))
     end
 
     it 'should decrypt' do
+      InlineEncryption.config[:key] = @default_key
       expect(InlineEncryption.decrypt(@str)).to eq('chunky')
     end
 
@@ -65,15 +70,21 @@ describe InlineEncryption::Base do
       expect(InlineEncryption.decrypt(@str, 'chunky')).to eq('chunky')
     end
 
+    it 'should fail to decrpyt and raise if using a public key to decrypt' do
+      InlineEncryption.config[:key] = @default_key.public_key
+      expect{ InlineEncryption.decrypt('whatevs') }.to raise_error(InlineEncryption::MisconfigurationError)
+    end
+
   end
 
   describe 'decrypt!' do
 
     before :all do
-      @str = Base64.encode64(@default_key.private_encrypt('chunky'))
+      @str = Base64.encode64(@default_key.public_encrypt('chunky'))
     end
 
     it 'should decrypt' do
+      InlineEncryption.config[:key] = @default_key
       expect(InlineEncryption.decrypt!(@str)).to eq('chunky')
     end
 


### PR DESCRIPTION
…ME.md

encrpyt methods will use public key and decrypt will use private key, as is conventional
code cleanup, update ci to use latest of common minor versions of ruby